### PR TITLE
Update Linked_selection.tex

### DIFF
--- a/Chapters/Linked_selection.tex
+++ b/Chapters/Linked_selection.tex
@@ -606,7 +606,7 @@ $c_1,\cdots,c_L$, then compounding equation \eqref{eqn:pi_loc_BGS_1}
 across these loci, the expected reduced diversity is approximately
 \begin{equation}
 \E[\pi] = \pi_0  \prod_{i=1}^L \left(1-\frac{\mu sh}{2(c_L+sh)^2}
-\right) \approx \exp \left( \sum_{i=1}^L \frac{\mu sh}{2(c_i+sh)^2} \right) \label{eqn:pi_loc_BGS}
+\right) \approx \pi_0 \exp \left( \sum_{i=1}^L - \frac{\mu sh}{2(c_i+sh)^2} \right) \label{eqn:pi_loc_BGS}
 \end{equation}
 To model an average neutral locus in a genomic region with a given recombination rate, we can imagine that our neutral locus is situated in the center of a large region with
 total recombination rate $C$ and total deleterious mutation rate $U$,


### PR DESCRIPTION
Updated eq 13.13 to include pi_0 in the approximation and retain the negative sign within the exponent.